### PR TITLE
Get attachment type fix

### DIFF
--- a/Sources/Utilities/ALMessage+Extension.swift
+++ b/Sources/Utilities/ALMessage+Extension.swift
@@ -346,8 +346,7 @@ extension ALMessage {
 
     private func getAttachmentType() -> ALKMessageType? {
         
-        guard let fileMeta = fileMeta, (fileMeta.contentType != nil) else { return nil }
-        let contentType = fileMeta.contentType
+        guard let fileMeta = fileMeta, let contentType = fileMeta.contentType else { return nil }
         guard let index = contentType.firstIndex(of: "/"), (index < contentType.endIndex) else { return nil }
         
         let contentPrefix = String(contentType.prefix(upTo: index))

--- a/Sources/Utilities/ALMessage+Extension.swift
+++ b/Sources/Utilities/ALMessage+Extension.swift
@@ -350,6 +350,8 @@ extension ALMessage {
         var contentPrefix = String()
         if let index = fileMeta.contentType.firstIndex(of: "/") {
             contentPrefix = String(fileMeta.contentType.prefix(upTo: index))
+        } else {
+            return nil
         }
         
         switch contentPrefix {

--- a/Sources/Utilities/ALMessage+Extension.swift
+++ b/Sources/Utilities/ALMessage+Extension.swift
@@ -345,15 +345,12 @@ extension ALMessage {
     }
 
     private func getAttachmentType() -> ALKMessageType? {
-        guard let fileMeta = fileMeta else { return nil }
         
-        var contentPrefix = String()
-        if let index = fileMeta.contentType.firstIndex(of: "/") {
-            contentPrefix = String(fileMeta.contentType.prefix(upTo: index))
-        } else {
-            return nil
-        }
+        guard let fileMeta = fileMeta, (fileMeta.contentType != nil) else { return nil }
+        guard let index = fileMeta.contentType.firstIndex(of: "/"), (index < fileMeta.contentType.endIndex) else { return nil }
         
+        let contentPrefix = String(fileMeta.contentType.prefix(upTo: index))
+
         switch contentPrefix {
         case "image":
             return .photo

--- a/Sources/Utilities/ALMessage+Extension.swift
+++ b/Sources/Utilities/ALMessage+Extension.swift
@@ -347,9 +347,10 @@ extension ALMessage {
     private func getAttachmentType() -> ALKMessageType? {
         
         guard let fileMeta = fileMeta, (fileMeta.contentType != nil) else { return nil }
-        guard let index = fileMeta.contentType.firstIndex(of: "/"), (index < fileMeta.contentType.endIndex) else { return nil }
+        let contentType = fileMeta.contentType
+        guard let index = contentType.firstIndex(of: "/"), (index < contentType.endIndex) else { return nil }
         
-        let contentPrefix = String(fileMeta.contentType.prefix(upTo: index))
+        let contentPrefix = String(contentType.prefix(upTo: index))
 
         switch contentPrefix {
         case "image":


### PR DESCRIPTION
## Summary
Added a return statement for cases when no contentPrefix is present in the fileMetaData